### PR TITLE
Update scheduled function resource type

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -60,7 +60,7 @@ resources:
       runtime: "nodejs10"
 
   - name: scheduledFirerunExt
-    type: firebaseextensions.v1beta.scheduledFunction
+    type: firebaseextensions.v1beta.function
     description: >-
       Create the fireRun.io daily report.
     properties:


### PR DESCRIPTION
API Change: As of May 21, the scheduled function resource type changes from 

`firebaseextensions.v1beta.scheduledFunction`

to

`firebaseextensions.v1beta.function`

This doesn't affect already-deployed extensions, but will affect new installs.